### PR TITLE
Replace `Drush` with `Drush Launcher`

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -104,7 +104,6 @@ sudo su vagrant <<'EOF'
 /usr/local/bin/composer global require "laravel/installer=~2.0"
 /usr/local/bin/composer global require "laravel/lumen-installer=~1.0"
 /usr/local/bin/composer global require "laravel/spark-installer=~2.0"
-/usr/local/bin/composer global require "drush/drush=~8"
 EOF
 
 # Set Some PHP CLI Settings
@@ -432,6 +431,13 @@ rm -rf flyway-commandline-4.2.0-linux-x64.tar.gz
 curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
 chmod +x wp-cli.phar
 mv wp-cli.phar /usr/local/bin/wp
+
+# Install Drush Launcher.
+
+curl --silent --location https://github.com/drush-ops/drush-launcher/releases/download/0.6.0/drush.phar --output drush.phar
+chmod +x drush.phar
+mv drush.phar /usr/local/bin/drush
+drush self-update
 
 # Install oh-my-zsh
 


### PR DESCRIPTION
Per official documentation's recommendation, I propose replacing globally available Drush (installed via composer) with the official [Drush Launcher](https://github.com/drush-ops/drush-launcher).

> It is recommended that Drupal 8 sites be [built using Composer, with Drush listed as a dependency](https://github.com/drupal-composer/drupal-project). ... To be able to call drush from anywhere, install the Drush Launcher. That is a small program which listens on your $PATH and hands control to a site-local Drush that is in the /vendor directory of your Composer project.

Drush Documentation
http://docs.drush.org/en/master/install/